### PR TITLE
log exception as warning

### DIFF
--- a/ios_device/util/utils.py
+++ b/ios_device/util/utils.py
@@ -113,7 +113,7 @@ def kperf_data(messages):
         try:
             _list.append(struct.unpack('<QLLQQQQLLQ', messages[p_record:p_record + 64]))
         except Exception as e:
-            logging.exception(e)
+            logging.warning(e)
         finally:
             p_record += 64
     return _list


### PR DESCRIPTION
Don’t thrown an error when InstrumentsServer shows this warning:

```
(16132 InstrumentServer) [ERROR] unpack requires a buffer of 64 bytes
   96  Traceback (most recent call last):
   97    File "C:\hostedtoolcache\windows\Python\3.9.6\x64\lib\site-packages\py_ios_device-2.1.1-py3.9.egg\ios_device\util\utils.py", line 114, in kperf_data
   98: struct.error: unpack requires a buffer of 64 bytes
```